### PR TITLE
Implement go-style profiling endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -72,6 +72,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,9 +100,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
@@ -115,32 +121,30 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstyle",
  "clap_lex",
- "once_cell",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -153,6 +157,15 @@ name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8227005286ec39567949b33df9896bcadfa6051bccca2488129f108ca23119"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -171,6 +184,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]
@@ -206,9 +228,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -223,6 +245,24 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -342,12 +382,11 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "headers"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.13.1",
- "bitflags",
+ "base64 0.21.3",
  "bytes",
  "headers-core",
  "http",
@@ -510,6 +549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+
+[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,9 +572,18 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -573,6 +627,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "mtop-client",
+ "pprof",
  "prometheus-client",
  "regex",
  "serde",
@@ -586,7 +641,7 @@ dependencies = [
 [[package]]
 name = "mtop-client"
 version = "0.6.3"
-source = "git+https://github.com/56quarters/mtop.git#b6523dd0b97c7e346ba775f770a1757db6756527"
+source = "git+https://github.com/56quarters/mtop.git#9ee8e4e2a80d90c3a381d1a8fa0c5aab74cab986"
 dependencies = [
  "rustls-pemfile",
  "rustls-webpki",
@@ -616,6 +671,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -718,6 +784,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pprof"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978385d59daf9269189d052ca8a84c1acfd0715c0599a5d5188d4acc078ca46a"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "protobuf",
+ "protobuf-codegen-pure",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +841,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
 ]
 
 [[package]]
@@ -800,14 +913,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -817,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -859,19 +972,32 @@ version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf14a7a466ce88b5eac3da815b53aefc208ce7e74d1c263aabb04d88c4abeb1"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.5",
  "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -1059,14 +1185,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "syn"
-version = "2.0.29"
+name = "stable_deref_trait"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "symbolic-common"
+version = "12.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0e9bc48b3852f36a84f8d0da275d50cb3c2b88b59b9ec35fdd8b7fa239e37d"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691e53bdc0702aba3a5abc2cffff89346fcbd4050748883c7e2f714b33a69045"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix 0.38.12",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1075,24 +1243,24 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix",
+ "rustix 0.37.23",
  "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1361,6 +1529,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,13 @@ tracing-subscriber = "0.3.17"
 warp = "0.3.5"
 mtop-client = { git = "https://github.com/56quarters/mtop.git" }
 
+# Profiling, disabled by default
+pprof = {version =  "0.12.1", features = ["protobuf-codec"] , optional = true}
+
+[features]
+default = []
+profile = ["dep:pprof"]
+
 [lib]
 name = "mkey_exporter"
 path = "src/mkey_exporter/lib.rs"

--- a/src/mkey_exporter/keys.rs
+++ b/src/mkey_exporter/keys.rs
@@ -12,18 +12,17 @@ impl<'a> LabelParser<'a> {
         Self { config }
     }
 
-    pub fn extract(&mut self, meta: &Meta) -> Vec<(String, String)> {
+    pub fn extract(&self, meta: &Meta) -> Vec<(String, String)> {
         let mut names_seen = HashSet::new();
         let mut value = String::new();
         let mut labels = Vec::new();
-
         for rule in self.config.rules.iter() {
             if names_seen.contains(&rule.label_name) {
                 continue;
             }
 
             if let Some(c) = rule.pattern.captures(&meta.key) {
-                names_seen.insert(rule.label_name.clone());
+                names_seen.insert(&rule.label_name);
 
                 c.expand(&rule.label_value, &mut value);
                 labels.push((rule.label_name.clone(), value.clone()));

--- a/src/mkey_exporter/lib.rs
+++ b/src/mkey_exporter/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod keys;
 pub mod metrics;
+pub mod profile;

--- a/src/mkey_exporter/metrics.rs
+++ b/src/mkey_exporter/metrics.rs
@@ -13,8 +13,8 @@ use warp::http::{HeaderValue, StatusCode};
 use warp::reply::Response;
 use warp::{Filter, Rejection, Reply};
 
-const DEFAULT_BUCKETS: &[f64] = &[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0];
 const TEXT_FORMAT: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+const DEFAULT_BUCKETS: &[f64] = &[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0];
 const RESULT_SUCCESS: UpdateResultLabels = UpdateResultLabels {
     result: UpdateResult::Success,
 };
@@ -37,9 +37,7 @@ impl RequestContext {
 /// a registry in the text exposition format at the path `/metrics` for `GET`
 /// requests. If an error is encountered, an HTTP 500 will be returned and the
 /// error will be logged.
-pub fn text_metrics_filter(
-    context: Arc<RequestContext>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn http_text_metrics(context: Arc<RequestContext>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path("metrics").and(warp::filters::method::get()).map(move || {
         let context = context.clone();
         let mut buf = String::new();

--- a/src/mkey_exporter/profile/mod.rs
+++ b/src/mkey_exporter/profile/mod.rs
@@ -1,0 +1,95 @@
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+use std::sync::Arc;
+use warp::http::header::CONTENT_TYPE;
+use warp::http::{HeaderValue, Response, StatusCode};
+use warp::{Filter, Rejection, Reply};
+
+#[cfg(not(feature = "profile"))]
+pub use nop::Profiler;
+#[cfg(feature = "profile")]
+pub use pull::Profiler;
+
+#[cfg(not(feature = "profile"))]
+mod nop;
+#[cfg(feature = "profile")]
+mod pull;
+
+const OCTET_STREAM: &str = "application/octet-stream";
+
+/// Construct and return a new `Profiler` CPU profiler. This may be a pprof CPU
+/// profiler or a no-op CPU profiler depending on build-time settings.
+pub fn build() -> Result<Profiler, ProfilerError> {
+    Profiler::new()
+}
+
+#[derive(Debug)]
+pub struct ProfilerError {
+    msg: String,
+    cause: Option<Box<dyn Error + Send + Sync + 'static>>,
+}
+
+impl ProfilerError {
+    pub fn msg<S>(msg: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            msg: msg.into(),
+            cause: None,
+        }
+    }
+
+    pub fn msg_cause<S, E>(msg: S, cause: E) -> Self
+    where
+        S: Into<String>,
+        E: Error + Send + Sync + 'static,
+    {
+        Self {
+            msg: msg.into(),
+            cause: Some(Box::new(cause)),
+        }
+    }
+}
+
+impl Display for ProfilerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(e) = &self.cause {
+            write!(f, "{}: {}", self.msg, e)
+        } else {
+            write!(f, "{}", self.msg)
+        }
+    }
+}
+
+impl Error for ProfilerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Some(e) = &self.cause {
+            Some(e.as_ref())
+        } else {
+            None
+        }
+    }
+}
+
+pub fn http_pprof(profiler: Arc<Profiler>) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    warp::path("debug")
+        .and(warp::path("pprof"))
+        .and(warp::path("profile"))
+        .and(warp::filters::method::get())
+        .map(move || {
+            let profiler = profiler.clone();
+            match profiler.proto() {
+                Ok(bytes) => {
+                    let mut res = Response::new(bytes);
+                    res.headers_mut()
+                        .insert(CONTENT_TYPE, HeaderValue::from_static(OCTET_STREAM));
+                    res.into_response()
+                }
+                Err(e) => {
+                    tracing::error!(message = "error building profiling report", error = %e);
+                    StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                }
+            }
+        })
+}

--- a/src/mkey_exporter/profile/nop.rs
+++ b/src/mkey_exporter/profile/nop.rs
@@ -1,0 +1,13 @@
+use crate::profile::ProfilerError;
+
+pub struct Profiler {}
+
+impl Profiler {
+    pub fn new() -> Result<Self, ProfilerError> {
+        Ok(Self {})
+    }
+
+    pub fn proto(&self) -> Result<Vec<u8>, ProfilerError> {
+        Err(ProfilerError::msg("not implemented"))
+    }
+}

--- a/src/mkey_exporter/profile/pull.rs
+++ b/src/mkey_exporter/profile/pull.rs
@@ -1,0 +1,36 @@
+use crate::profile::ProfilerError;
+use pprof::protos::Message;
+use pprof::{ProfilerGuard, ProfilerGuardBuilder};
+use std::ffi::c_int;
+
+const PROFILE_FREQUENCY_HZ: c_int = 1000;
+const PROFILE_BLOCK_LIST: &[&str] = &["libc", "libgcc", "pthread", "vdso"];
+
+pub struct Profiler {
+    guard: ProfilerGuard<'static>,
+}
+
+impl Profiler {
+    pub fn new() -> Result<Self, ProfilerError> {
+        let guard = ProfilerGuardBuilder::default()
+            .frequency(PROFILE_FREQUENCY_HZ)
+            .blocklist(PROFILE_BLOCK_LIST)
+            .build()
+            .map_err(|e| ProfilerError::msg_cause("cannot build profiler", e))?;
+
+        Ok(Self { guard })
+    }
+
+    pub fn proto(&self) -> Result<Vec<u8>, ProfilerError> {
+        self.guard
+            .report()
+            .build()
+            .and_then(|report| report.pprof())
+            .map_err(|e| ProfilerError::msg_cause("cannot build profile report", e))
+            .and_then(|profile| {
+                profile
+                    .write_to_bytes()
+                    .map_err(|e| ProfilerError::msg_cause("cannot encode as protobuf", e))
+            })
+    }
+}


### PR DESCRIPTION
Add `/debug/pprof/profile` endpoint for dumping profiling information in protobuf format using the `pprof` crate. This feature is disabled by default and must be enabled at build time using the `profile` feature.

See #2